### PR TITLE
Fix multipart/mixed file uploads from Opera

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -181,11 +181,20 @@ Parser.prototype.write = function (chunk) {
           // message end.
           // parent ends, look for a new part in the grandparent.
           parser.part = parser.part.parent;
+          var ended_part = parser.part;
           if (parser.part !== parser)
             emit(parser, "onPartEnd", parser.part);
           parser.part = parser.part.parent;
           parser.state = S.NEW_PART;
-          parser.buffer = parser.buffer.substr(boundary.length + 4);
+          if (ended_part.isMultiPart) {
+            // skip the multipart epilogue
+            var epilogue_end = parser.buffer.indexOf(parser.part.boundary);
+            if (epilogue_end !== false) {
+              parser.buffer = parser.buffer.substr(epilogue_end);
+            }
+          } else {
+            parser.buffer = parser.buffer.substr(boundary.length + 4);
+          }
         } else {
           // another part coming for the parent message.
           parser.part = parser.part.parent;


### PR DESCRIPTION
Multipart.parse produces an exception "Malformed: data before the boundary" on file uploads made by Opera browser with HTML5 multiple file inputs.
Fixed by skipping redundant "epilogue" areas after multipart/mixed body parts (see http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html for details).
